### PR TITLE
chore: ignore local runtime and tooling artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,21 @@ pane-header
 # Web
 web/node_modules/
 web/dist/
+web/tsconfig.tsbuildinfo
+
+# Local agent/tooling state
+.omc/
+.claude/
+.sisyphus/
+.archive/
+
+# Local scratch and logs
+tmux-*.log
+*.hup
+log.txt
+Untitled
+todos.md
+
+# Runtime-generated helper scripts
+scripts/apply_new_window_group.sh
+scripts/new_window_with_group.sh


### PR DESCRIPTION
## Summary
- ignore local agent/tooling state directories and scratch files that should not be tracked
- ignore runtime-generated helper scripts and tmux logs generated during local tabby sessions
- keep repository status clean so only intentional source changes appear

## Files
- `.gitignore`