### PR TITLE
refactor: consolidate config/state to XDG-style paths

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -161,18 +161,13 @@ The `&` backgrounds `tmux split-window`, not the sidebar. The PID saved is tmux'
 
 ## Medium Bugs
 
-### BUG-007: Config Path Hardcoded
+### BUG-007: Config Path Hardcoded -- RESOLVED
 **File**: `pkg/config/config.go`
 
-**Problem**:
-```go
-return filepath.Join(home, ".tmux/plugins/tmux-tabs/config.yaml")
-```
-
-No support for:
-- `$XDG_CONFIG_HOME`
-- Development paths
-- Custom config locations
+**Resolution**: Centralized in `pkg/paths/paths.go` with XDG-style layout:
+- Config: `~/.config/tabby/config.yaml` (env: `TABBY_CONFIG_DIR`)
+- State: `~/.local/state/tabby/` (env: `TABBY_STATE_DIR`)
+- Legacy paths fall back transparently with deprecation notice
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ install: build
 	@echo "Installing to ~/.tmux/plugins/tmux-tabs/"
 	@mkdir -p ~/.tmux/plugins/tmux-tabs/bin
 	@mkdir -p ~/.tmux/plugins/tmux-tabs/scripts
+	@mkdir -p ~/.config/tabby
 	@cp $(RENDER_STATUS) ~/.tmux/plugins/tmux-tabs/bin/
 	@cp $(RENDER_TAB) ~/.tmux/plugins/tmux-tabs/bin/
 	@cp $(TABBY_DAEMON) ~/.tmux/plugins/tmux-tabs/bin/
@@ -91,7 +92,7 @@ install: build
 	@cp $(TABBAR) ~/.tmux/plugins/tmux-tabs/bin/
 	@cp scripts/*.sh ~/.tmux/plugins/tmux-tabs/scripts/
 	@cp tmux-tabs.tmux ~/.tmux/plugins/tmux-tabs/
-	@cp config.yaml ~/.tmux/plugins/tmux-tabs/
+	@test -f ~/.config/tabby/config.yaml || cp config.yaml ~/.config/tabby/config.yaml
 	@chmod +x ~/.tmux/plugins/tmux-tabs/bin/*
 	@chmod +x ~/.tmux/plugins/tmux-tabs/scripts/*
 	@chmod +x ~/.tmux/plugins/tmux-tabs/tmux-tabs.tmux
@@ -107,8 +108,8 @@ sync: build
 	@cp $(TABBAR) ~/.tmux/plugins/tmux-tabs/bin/
 	@cp scripts/*.sh ~/.tmux/plugins/tmux-tabs/scripts/
 	@cp tmux-tabs.tmux ~/.tmux/plugins/tmux-tabs/
-	@cp config.yaml ~/.tmux/plugins/tmux-tabs/
-	@echo "Synced to ~/.tmux/plugins/tmux-tabs/"
+	@cp config.yaml ~/.config/tabby/config.yaml
+	@echo "Synced to ~/.tmux/plugins/tmux-tabs/ (config -> ~/.config/tabby/)"
 
 # Clean build artifacts
 clean:
@@ -135,7 +136,7 @@ help:
 	@echo "  test-e2e       - Run E2E integration tests"
 	@echo "  capture-visual - Capture visual screenshots"
 	@echo "  update-baseline- Update baseline screenshots"
-	@echo "  install        - Install to ~/.tmux/plugins/tmux-tabs/"
+	@echo "  install        - Install binaries + config (~/.config/tabby/config.yaml)"
 	@echo "  sync           - Sync dev changes to install location"
 	@echo "  clean          - Remove build artifacts"
 	@echo "  deps           - Download Go dependencies"

--- a/README.md
+++ b/README.md
@@ -216,7 +216,19 @@ This approach doesn't require SSH config changes and won't interfere with other 
 
 ## Configuration
 
-Edit `~/.tmux/plugins/tabby/config.yaml`:
+### File Locations
+
+| Category | Path | Env Override |
+|----------|------|-------------|
+| Config | `~/.config/tabby/config.yaml` | `TABBY_CONFIG_DIR` |
+| Pet state | `~/.local/state/tabby/pet.json` | `TABBY_STATE_DIR` |
+| Thought cache | `~/.local/state/tabby/thought_buffer.txt` | `TABBY_STATE_DIR` |
+| Web token | `~/.local/state/tabby/web-token` | `TABBY_STATE_DIR` |
+| Runtime | `/tmp/tabby-*` | -- |
+
+Legacy paths (`~/.tmux/plugins/tmux-tabs/config.yaml`, `~/.config/tabby/{pet.json,web-token}`) are detected automatically with a deprecation notice.
+
+Edit `~/.config/tabby/config.yaml`:
 
 ```yaml
 # Tab bar position: top, bottom, or off
@@ -427,7 +439,7 @@ cd ~/.tmux/plugins/tabby
 Tabby Web runs a local-only bridge that exposes tmux + sidebar over WebSocket. The bridge only binds to loopback and requires user/password for access.
 
 ### Enable in config (default disabled)
-Add this to `~/.tmux/plugins/tmux-tabs/config.yaml`:
+Add this to `~/.config/tabby/config.yaml`:
 ```yaml
 web:
   enabled: true
@@ -456,7 +468,7 @@ npm run dev
 ### Connect in browser
 Open `http://127.0.0.1:5173/?token=<token>&user=<user>&pass=<pass>&pane=<pane_id>&ws=127.0.0.1:8080`
 
-- Token is stored at `~/.config/tabby/web-token`
+- Token is stored at `~/.local/state/tabby/web-token`
 - Pane ID can be retrieved with `tmux list-panes -t tabby-web-test -F '#{pane_id}'`
 - The bridge rejects non-loopback requests
 

--- a/cmd/tabby-daemon/llm.go
+++ b/cmd/tabby-daemon/llm.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/b/tmux-tabs/pkg/paths"
 	"github.com/teilomillet/gollm"
 	"github.com/teilomillet/gollm/llm"
 )
@@ -100,8 +100,7 @@ func initLLM(provider, model, apiKey string) error {
 	llmClient = client
 
 	// Set up thought buffer persistence path
-	homeDir, _ := os.UserHomeDir()
-	thoughtBufferPath = filepath.Join(homeDir, ".config", "tabby", "thought_buffer.txt")
+	thoughtBufferPath = paths.StatePath("thought_buffer.txt")
 
 	// Load existing thoughts from disk
 	loadThoughtBuffer()
@@ -147,9 +146,8 @@ func saveThoughtBuffer() {
 		return
 	}
 
-	// Ensure directory exists
-	dir := filepath.Dir(thoughtBufferPath)
-	os.MkdirAll(dir, 0755)
+	// Ensure state directory exists
+	paths.EnsureStateDir()
 
 	thoughtBufferMutex.Lock()
 	thoughts := make([]string, len(thoughtBuffer))

--- a/cmd/tabby-web-bridge/auth.go
+++ b/cmd/tabby-web-bridge/auth.go
@@ -11,15 +11,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/b/tmux-tabs/pkg/paths"
 	"github.com/skip2/go-qrcode"
 )
 
 func DefaultTokenPath() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(home, ".config", "tabby", "web-token"), nil
+	return paths.StatePath("web-token"), nil
 }
 
 func LoadOrGenerateToken(path string) (string, error) {

--- a/cmd/tabby-web-bridge/main.go
+++ b/cmd/tabby-web-bridge/main.go
@@ -14,7 +14,7 @@ func main() {
 	host := flag.String("host", "127.0.0.1", "HTTP server host (loopback only)")
 	port := flag.Int("port", 8080, "HTTP server port")
 	sessionID := flag.String("session", "", "tmux session ID")
-	tokenFile := flag.String("token-file", "", "token file path (default: ~/.config/tabby/web-token)")
+	tokenFile := flag.String("token-file", "", "token file path (default: ~/.local/state/tabby/web-token)")
 	regenerateToken := flag.Bool("regenerate-token", false, "regenerate auth token on startup")
 	authUser := flag.String("auth-user", "", "required username for web access")
 	authPass := flag.String("auth-pass", "", "required password for web access")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,8 +1,7 @@
 package config
 
 import (
-	"os"
-	"path/filepath"
+	"github.com/b/tmux-tabs/pkg/paths"
 )
 
 type Config struct {
@@ -389,9 +388,5 @@ type Indicator struct {
 }
 
 func DefaultConfigPath() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "config.yaml"
-	}
-	return filepath.Join(home, ".tmux/plugins/tmux-tabs/config.yaml")
+	return paths.ConfigPath()
 }

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -1,0 +1,163 @@
+// Package paths provides centralized path resolution for Tabby's config and state files.
+//
+// Target layout (XDG-style):
+//
+//	Config:  ~/.config/tabby/config.yaml   (override: TABBY_CONFIG_DIR)
+//	State:   ~/.local/state/tabby/         (override: TABBY_STATE_DIR)
+//	Runtime: /tmp/tabby-*                  (unchanged)
+//
+// Legacy paths are supported transparently: if the new path doesn't exist but
+// the legacy path does, the legacy path is used with a one-time deprecation
+// notice to stderr.
+package paths
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+var (
+	configDirOnce   sync.Once
+	configDirCached string
+
+	stateDirOnce   sync.Once
+	stateDirCached string
+)
+
+// legacyConfigDir returns the old config path: ~/.tmux/plugins/tmux-tabs/
+func legacyConfigDir(home string) string {
+	return filepath.Join(home, ".tmux", "plugins", "tmux-tabs")
+}
+
+// legacyStateDir returns the old state path (state files lived alongside config): ~/.config/tabby/
+func legacyStateDir(home string) string {
+	return filepath.Join(home, ".config", "tabby")
+}
+
+// ConfigDir resolves the config directory.
+// Priority: TABBY_CONFIG_DIR env > ~/.config/tabby/ > legacy ~/.tmux/plugins/tmux-tabs/
+func ConfigDir() string {
+	configDirOnce.Do(func() {
+		configDirCached = resolveConfigDir()
+	})
+	return configDirCached
+}
+
+func resolveConfigDir() string {
+	if env := os.Getenv("TABBY_CONFIG_DIR"); env != "" {
+		return env
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "."
+	}
+
+	newDir := filepath.Join(home, ".config", "tabby")
+	legacyDir := legacyConfigDir(home)
+	legacyConfig := filepath.Join(legacyDir, "config.yaml")
+
+	// Legacy path takes priority when it exists -- this is what was
+	// actually in use before the migration. New path only wins once
+	// the user has explicitly removed the legacy config.
+	if fileExists(legacyConfig) {
+		newConfig := filepath.Join(newDir, "config.yaml")
+		if fileExists(newConfig) {
+			fmt.Fprintf(os.Stderr, "[tabby] deprecation: config exists at both %s and %s -- using legacy; delete legacy when ready to migrate\n", legacyDir, newDir)
+		} else {
+			fmt.Fprintf(os.Stderr, "[tabby] deprecation: reading config from %s -- move it to %s\n", legacyDir, newDir)
+		}
+		return legacyDir
+	}
+
+	// No legacy config: use new path (migrated or fresh install)
+	return newDir
+}
+
+// StateDir resolves the state directory.
+// Priority: TABBY_STATE_DIR env > ~/.local/state/tabby/ > legacy ~/.config/tabby/
+func StateDir() string {
+	stateDirOnce.Do(func() {
+		stateDirCached = resolveStateDir()
+	})
+	return stateDirCached
+}
+
+func resolveStateDir() string {
+	if env := os.Getenv("TABBY_STATE_DIR"); env != "" {
+		return env
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "."
+	}
+
+	newDir := filepath.Join(home, ".local", "state", "tabby")
+
+	if dirExists(newDir) {
+		return newDir
+	}
+
+	// Check if any state files exist at the legacy location
+	legDir := legacyStateDir(home)
+	stateFiles := []string{"pet.json", "thought_buffer.txt", "web-token"}
+	for _, f := range stateFiles {
+		if fileExists(filepath.Join(legDir, f)) {
+			fmt.Fprintf(os.Stderr, "[tabby] deprecation: reading state from %s -- move state files to %s\n", legDir, newDir)
+			return legDir
+		}
+	}
+
+	// Fresh install: return the new canonical path
+	return newDir
+}
+
+// ConfigPath returns the full path to config.yaml.
+func ConfigPath() string {
+	return filepath.Join(ConfigDir(), "config.yaml")
+}
+
+// StatePath returns the full path to a state file (e.g. "pet.json").
+func StatePath(filename string) string {
+	return filepath.Join(StateDir(), filename)
+}
+
+// EnsureConfigDir creates the config directory if it doesn't exist and returns its path.
+func EnsureConfigDir() (string, error) {
+	dir := ConfigDir()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", fmt.Errorf("create config dir %s: %w", dir, err)
+	}
+	return dir, nil
+}
+
+// EnsureStateDir creates the state directory if it doesn't exist and returns its path.
+func EnsureStateDir() (string, error) {
+	dir := StateDir()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", fmt.Errorf("create state dir %s: %w", dir, err)
+	}
+	return dir, nil
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+// ResetForTest clears cached values so tests can re-run resolution logic.
+// Only use in tests.
+func ResetForTest() {
+	configDirOnce = sync.Once{}
+	configDirCached = ""
+	stateDirOnce = sync.Once{}
+	stateDirCached = ""
+}

--- a/pkg/paths/paths_test.go
+++ b/pkg/paths/paths_test.go
@@ -1,0 +1,220 @@
+package paths
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func setupTestDirs(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	// Unset env vars so they don't interfere
+	t.Setenv("TABBY_CONFIG_DIR", "")
+	t.Setenv("TABBY_STATE_DIR", "")
+	// Override HOME so resolution uses our temp dirs
+	t.Setenv("HOME", tmp)
+	ResetForTest()
+	return tmp
+}
+
+func TestConfigDir_EnvOverride(t *testing.T) {
+	tmp := setupTestDirs(t)
+	override := filepath.Join(tmp, "custom-config")
+	os.MkdirAll(override, 0755)
+	t.Setenv("TABBY_CONFIG_DIR", override)
+	ResetForTest()
+
+	got := ConfigDir()
+	if got != override {
+		t.Errorf("ConfigDir() = %q, want %q", got, override)
+	}
+}
+
+func TestConfigDir_LegacyWinsWhenBothExist(t *testing.T) {
+	tmp := setupTestDirs(t)
+
+	// Create config at both new and legacy paths -- legacy should win
+	newDir := filepath.Join(tmp, ".config", "tabby")
+	os.MkdirAll(newDir, 0755)
+	os.WriteFile(filepath.Join(newDir, "config.yaml"), []byte("new"), 0644)
+
+	legDir := filepath.Join(tmp, ".tmux", "plugins", "tmux-tabs")
+	os.MkdirAll(legDir, 0755)
+	os.WriteFile(filepath.Join(legDir, "config.yaml"), []byte("old"), 0644)
+
+	got := ConfigDir()
+	if got != legDir {
+		t.Errorf("ConfigDir() = %q, want legacy path %q (legacy wins when both exist)", got, legDir)
+	}
+}
+
+func TestConfigDir_NewPathWinsAfterMigration(t *testing.T) {
+	tmp := setupTestDirs(t)
+
+	// Only new path exists (legacy removed = migration complete)
+	newDir := filepath.Join(tmp, ".config", "tabby")
+	os.MkdirAll(newDir, 0755)
+	os.WriteFile(filepath.Join(newDir, "config.yaml"), []byte("new"), 0644)
+
+	got := ConfigDir()
+	if got != newDir {
+		t.Errorf("ConfigDir() = %q, want new path %q", got, newDir)
+	}
+}
+
+func TestConfigDir_FallbackToLegacy(t *testing.T) {
+	tmp := setupTestDirs(t)
+
+	// Only create legacy path
+	legDir := filepath.Join(tmp, ".tmux", "plugins", "tmux-tabs")
+	os.MkdirAll(legDir, 0755)
+	os.WriteFile(filepath.Join(legDir, "config.yaml"), []byte("old"), 0644)
+
+	got := ConfigDir()
+	if got != legDir {
+		t.Errorf("ConfigDir() = %q, want legacy path %q", got, legDir)
+	}
+}
+
+func TestConfigDir_FreshInstall(t *testing.T) {
+	tmp := setupTestDirs(t)
+
+	// Neither path exists
+	want := filepath.Join(tmp, ".config", "tabby")
+	got := ConfigDir()
+	if got != want {
+		t.Errorf("ConfigDir() = %q, want canonical %q", got, want)
+	}
+}
+
+func TestStateDir_EnvOverride(t *testing.T) {
+	tmp := setupTestDirs(t)
+	override := filepath.Join(tmp, "custom-state")
+	os.MkdirAll(override, 0755)
+	t.Setenv("TABBY_STATE_DIR", override)
+	ResetForTest()
+
+	got := StateDir()
+	if got != override {
+		t.Errorf("StateDir() = %q, want %q", got, override)
+	}
+}
+
+func TestStateDir_NewPathWins(t *testing.T) {
+	tmp := setupTestDirs(t)
+
+	// Create new state dir (just needs to exist as a directory)
+	newDir := filepath.Join(tmp, ".local", "state", "tabby")
+	os.MkdirAll(newDir, 0755)
+
+	// Also create legacy state file
+	legDir := filepath.Join(tmp, ".config", "tabby")
+	os.MkdirAll(legDir, 0755)
+	os.WriteFile(filepath.Join(legDir, "pet.json"), []byte("{}"), 0644)
+
+	got := StateDir()
+	if got != newDir {
+		t.Errorf("StateDir() = %q, want new path %q", got, newDir)
+	}
+}
+
+func TestStateDir_FallbackToLegacy(t *testing.T) {
+	tmp := setupTestDirs(t)
+
+	// Only create legacy state file
+	legDir := filepath.Join(tmp, ".config", "tabby")
+	os.MkdirAll(legDir, 0755)
+	os.WriteFile(filepath.Join(legDir, "pet.json"), []byte("{}"), 0644)
+
+	got := StateDir()
+	if got != legDir {
+		t.Errorf("StateDir() = %q, want legacy path %q", got, legDir)
+	}
+}
+
+func TestStateDir_FreshInstall(t *testing.T) {
+	tmp := setupTestDirs(t)
+
+	want := filepath.Join(tmp, ".local", "state", "tabby")
+	got := StateDir()
+	if got != want {
+		t.Errorf("StateDir() = %q, want canonical %q", got, want)
+	}
+}
+
+func TestConfigPath(t *testing.T) {
+	tmp := setupTestDirs(t)
+	want := filepath.Join(tmp, ".config", "tabby", "config.yaml")
+	got := ConfigPath()
+	if got != want {
+		t.Errorf("ConfigPath() = %q, want %q", got, want)
+	}
+}
+
+func TestStatePath(t *testing.T) {
+	tmp := setupTestDirs(t)
+	want := filepath.Join(tmp, ".local", "state", "tabby", "pet.json")
+	got := StatePath("pet.json")
+	if got != want {
+		t.Errorf("StatePath(\"pet.json\") = %q, want %q", got, want)
+	}
+}
+
+func TestEnsureConfigDir_Creates(t *testing.T) {
+	tmp := setupTestDirs(t)
+	expected := filepath.Join(tmp, ".config", "tabby")
+
+	dir, err := EnsureConfigDir()
+	if err != nil {
+		t.Fatalf("EnsureConfigDir() error: %v", err)
+	}
+	if dir != expected {
+		t.Errorf("EnsureConfigDir() = %q, want %q", dir, expected)
+	}
+	if !dirExists(expected) {
+		t.Errorf("EnsureConfigDir() did not create directory %q", expected)
+	}
+}
+
+func TestEnsureStateDir_Creates(t *testing.T) {
+	tmp := setupTestDirs(t)
+	expected := filepath.Join(tmp, ".local", "state", "tabby")
+
+	dir, err := EnsureStateDir()
+	if err != nil {
+		t.Fatalf("EnsureStateDir() error: %v", err)
+	}
+	if dir != expected {
+		t.Errorf("EnsureStateDir() = %q, want %q", dir, expected)
+	}
+	if !dirExists(expected) {
+		t.Errorf("EnsureStateDir() did not create directory %q", expected)
+	}
+}
+
+func TestStateDir_FallbackOnThoughtBuffer(t *testing.T) {
+	tmp := setupTestDirs(t)
+
+	legDir := filepath.Join(tmp, ".config", "tabby")
+	os.MkdirAll(legDir, 0755)
+	os.WriteFile(filepath.Join(legDir, "thought_buffer.txt"), []byte("hello"), 0644)
+
+	got := StateDir()
+	if got != legDir {
+		t.Errorf("StateDir() = %q, want legacy path %q (triggered by thought_buffer.txt)", got, legDir)
+	}
+}
+
+func TestStateDir_FallbackOnWebToken(t *testing.T) {
+	tmp := setupTestDirs(t)
+
+	legDir := filepath.Join(tmp, ".config", "tabby")
+	os.MkdirAll(legDir, 0755)
+	os.WriteFile(filepath.Join(legDir, "web-token"), []byte("tok"), 0644)
+
+	got := StateDir()
+	if got != legDir {
+		t.Errorf("StateDir() = %q, want legacy path %q (triggered by web-token)", got, legDir)
+	}
+}

--- a/scripts/_config_path.sh
+++ b/scripts/_config_path.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Shared config path resolution for Tabby shell scripts.
+# Source this file; it sets TABBY_CONFIG_FILE.
+#
+# Resolution order:
+#   1. TABBY_CONFIG_DIR env var
+#   2. ~/.config/tabby/config.yaml  (new canonical path)
+#   3. ~/.tmux/plugins/tmux-tabs/config.yaml  (legacy)
+
+if [ -n "$TABBY_CONFIG_DIR" ]; then
+    TABBY_CONFIG_FILE="$TABBY_CONFIG_DIR/config.yaml"
+elif [ -f "$HOME/.config/tabby/config.yaml" ]; then
+    TABBY_CONFIG_FILE="$HOME/.config/tabby/config.yaml"
+elif [ -f "$HOME/.tmux/plugins/tmux-tabs/config.yaml" ]; then
+    echo "[tabby] deprecation: reading config from ~/.tmux/plugins/tmux-tabs/ -- move it to ~/.config/tabby/" >&2
+    TABBY_CONFIG_FILE="$HOME/.tmux/plugins/tmux-tabs/config.yaml"
+else
+    # Default to new canonical path (will be created on install)
+    TABBY_CONFIG_FILE="$HOME/.config/tabby/config.yaml"
+fi

--- a/scripts/set_group_working_dir.sh
+++ b/scripts/set_group_working_dir.sh
@@ -10,7 +10,10 @@ if [ -z "$GROUP_NAME" ] || [ -z "$WORKING_DIR" ]; then
     exit 1
 fi
 
-CONFIG_FILE="$HOME/.tmux/plugins/tmux-tabs/config.yaml"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=_config_path.sh
+source "$SCRIPT_DIR/_config_path.sh"
+CONFIG_FILE="$TABBY_CONFIG_FILE"
 
 if [ ! -f "$CONFIG_FILE" ]; then
     echo "Config file not found: $CONFIG_FILE"

--- a/scripts/set_sidebar_order.sh
+++ b/scripts/set_sidebar_order.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
-CONFIG_FILE="$HOME/.tmux/plugins/tmux-tabs/config.yaml"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=_config_path.sh
+source "$SCRIPT_DIR/_config_path.sh"
+CONFIG_FILE="$TABBY_CONFIG_FILE"
 ORDER="${1:-index}"
 
 if [ "$ORDER" = "index" ]; then

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -2,8 +2,8 @@ FROM golang:1.24-bullseye
 RUN apt-get update && apt-get install -y ca-certificates tmux
 COPY . /plugin
 WORKDIR /plugin
-RUN mkdir -p /root/.tmux/plugins/tmux-tabs
-RUN cp config.yaml /root/.tmux/plugins/tmux-tabs/
+RUN mkdir -p /root/.tmux/plugins/tmux-tabs /root/.config/tabby
+RUN cp config.yaml /root/.config/tabby/
 RUN ln -s /plugin /root/.tmux/plugins/tmux-tabs
 RUN go build -o bin/render-status cmd/render-status/main.go
 RUN go build -o bin/sidebar-renderer cmd/sidebar-renderer/main.go


### PR DESCRIPTION
## Summary
- Adds `pkg/paths` package for centralized path resolution with `sync.Once` caching
- Config moves to `~/.config/tabby/config.yaml`, state to `~/.local/state/tabby/`
- Env overrides: `TABBY_CONFIG_DIR`, `TABBY_STATE_DIR`
- Legacy paths (`~/.tmux/plugins/tmux-tabs/`, `~/.config/tabby/` for state) fall back transparently with deprecation notice
- All 7 Go consumers pivot through `pkg/paths`; shell scripts use shared `_config_path.sh` helper
- Resolves BUG-007

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./pkg/paths/...` -- 14 unit tests (env overrides, legacy fallback, fresh install, both-exist priority)
- [x] `go test ./...` -- all existing tests pass
- [x] End-to-end: rebuilt daemon, restarted sidebar, config + state read from new paths