### PR TITLE
chore: remove legacy path fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,6 @@ This approach doesn't require SSH config changes and won't interfere with other 
 | Web token | `~/.local/state/tabby/web-token` | `TABBY_STATE_DIR` |
 | Runtime | `/tmp/tabby-*` | -- |
 
-Legacy paths (`~/.tmux/plugins/tmux-tabs/config.yaml`, `~/.config/tabby/{pet.json,web-token}`) are detected automatically with a deprecation notice.
 
 Edit `~/.config/tabby/config.yaml`:
 

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -1,14 +1,10 @@
 // Package paths provides centralized path resolution for Tabby's config and state files.
 //
-// Target layout (XDG-style):
+// Layout (XDG-style):
 //
 //	Config:  ~/.config/tabby/config.yaml   (override: TABBY_CONFIG_DIR)
 //	State:   ~/.local/state/tabby/         (override: TABBY_STATE_DIR)
 //	Runtime: /tmp/tabby-*                  (unchanged)
-//
-// Legacy paths are supported transparently: if the new path doesn't exist but
-// the legacy path does, the legacy path is used with a one-time deprecation
-// notice to stderr.
 package paths
 
 import (
@@ -26,93 +22,40 @@ var (
 	stateDirCached string
 )
 
-// legacyConfigDir returns the old config path: ~/.tmux/plugins/tmux-tabs/
-func legacyConfigDir(home string) string {
-	return filepath.Join(home, ".tmux", "plugins", "tmux-tabs")
-}
-
-// legacyStateDir returns the old state path (state files lived alongside config): ~/.config/tabby/
-func legacyStateDir(home string) string {
-	return filepath.Join(home, ".config", "tabby")
-}
-
 // ConfigDir resolves the config directory.
-// Priority: TABBY_CONFIG_DIR env > ~/.config/tabby/ > legacy ~/.tmux/plugins/tmux-tabs/
+// Priority: TABBY_CONFIG_DIR env > ~/.config/tabby/
 func ConfigDir() string {
 	configDirOnce.Do(func() {
-		configDirCached = resolveConfigDir()
+		if env := os.Getenv("TABBY_CONFIG_DIR"); env != "" {
+			configDirCached = env
+		} else {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				configDirCached = "."
+			} else {
+				configDirCached = filepath.Join(home, ".config", "tabby")
+			}
+		}
 	})
 	return configDirCached
 }
 
-func resolveConfigDir() string {
-	if env := os.Getenv("TABBY_CONFIG_DIR"); env != "" {
-		return env
-	}
-
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "."
-	}
-
-	newDir := filepath.Join(home, ".config", "tabby")
-	legacyDir := legacyConfigDir(home)
-	legacyConfig := filepath.Join(legacyDir, "config.yaml")
-
-	// Legacy path takes priority when it exists -- this is what was
-	// actually in use before the migration. New path only wins once
-	// the user has explicitly removed the legacy config.
-	if fileExists(legacyConfig) {
-		newConfig := filepath.Join(newDir, "config.yaml")
-		if fileExists(newConfig) {
-			fmt.Fprintf(os.Stderr, "[tabby] deprecation: config exists at both %s and %s -- using legacy; delete legacy when ready to migrate\n", legacyDir, newDir)
-		} else {
-			fmt.Fprintf(os.Stderr, "[tabby] deprecation: reading config from %s -- move it to %s\n", legacyDir, newDir)
-		}
-		return legacyDir
-	}
-
-	// No legacy config: use new path (migrated or fresh install)
-	return newDir
-}
-
 // StateDir resolves the state directory.
-// Priority: TABBY_STATE_DIR env > ~/.local/state/tabby/ > legacy ~/.config/tabby/
+// Priority: TABBY_STATE_DIR env > ~/.local/state/tabby/
 func StateDir() string {
 	stateDirOnce.Do(func() {
-		stateDirCached = resolveStateDir()
+		if env := os.Getenv("TABBY_STATE_DIR"); env != "" {
+			stateDirCached = env
+		} else {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				stateDirCached = "."
+			} else {
+				stateDirCached = filepath.Join(home, ".local", "state", "tabby")
+			}
+		}
 	})
 	return stateDirCached
-}
-
-func resolveStateDir() string {
-	if env := os.Getenv("TABBY_STATE_DIR"); env != "" {
-		return env
-	}
-
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "."
-	}
-
-	newDir := filepath.Join(home, ".local", "state", "tabby")
-
-	if dirExists(newDir) {
-		return newDir
-	}
-
-	// Check if any state files exist at the legacy location
-	legDir := legacyStateDir(home)
-	stateFiles := []string{"pet.json", "thought_buffer.txt", "web-token"}
-	for _, f := range stateFiles {
-		if fileExists(filepath.Join(legDir, f)) {
-			fmt.Fprintf(os.Stderr, "[tabby] deprecation: reading state from %s -- move state files to %s\n", legDir, newDir)
-			return legDir
-		}
-	}
-
-	// Fresh install: return the new canonical path
-	return newDir
 }
 
 // ConfigPath returns the full path to config.yaml.
@@ -141,16 +84,6 @@ func EnsureStateDir() (string, error) {
 		return "", fmt.Errorf("create state dir %s: %w", dir, err)
 	}
 	return dir, nil
-}
-
-func fileExists(path string) bool {
-	info, err := os.Stat(path)
-	return err == nil && !info.IsDir()
-}
-
-func dirExists(path string) bool {
-	info, err := os.Stat(path)
-	return err == nil && info.IsDir()
 }
 
 // ResetForTest clears cached values so tests can re-run resolution logic.

--- a/pkg/paths/paths_test.go
+++ b/pkg/paths/paths_test.go
@@ -9,10 +9,8 @@ import (
 func setupTestDirs(t *testing.T) string {
 	t.Helper()
 	tmp := t.TempDir()
-	// Unset env vars so they don't interfere
 	t.Setenv("TABBY_CONFIG_DIR", "")
 	t.Setenv("TABBY_STATE_DIR", "")
-	// Override HOME so resolution uses our temp dirs
 	t.Setenv("HOME", tmp)
 	ResetForTest()
 	return tmp
@@ -25,66 +23,16 @@ func TestConfigDir_EnvOverride(t *testing.T) {
 	t.Setenv("TABBY_CONFIG_DIR", override)
 	ResetForTest()
 
-	got := ConfigDir()
-	if got != override {
+	if got := ConfigDir(); got != override {
 		t.Errorf("ConfigDir() = %q, want %q", got, override)
 	}
 }
 
-func TestConfigDir_LegacyWinsWhenBothExist(t *testing.T) {
+func TestConfigDir_Default(t *testing.T) {
 	tmp := setupTestDirs(t)
-
-	// Create config at both new and legacy paths -- legacy should win
-	newDir := filepath.Join(tmp, ".config", "tabby")
-	os.MkdirAll(newDir, 0755)
-	os.WriteFile(filepath.Join(newDir, "config.yaml"), []byte("new"), 0644)
-
-	legDir := filepath.Join(tmp, ".tmux", "plugins", "tmux-tabs")
-	os.MkdirAll(legDir, 0755)
-	os.WriteFile(filepath.Join(legDir, "config.yaml"), []byte("old"), 0644)
-
-	got := ConfigDir()
-	if got != legDir {
-		t.Errorf("ConfigDir() = %q, want legacy path %q (legacy wins when both exist)", got, legDir)
-	}
-}
-
-func TestConfigDir_NewPathWinsAfterMigration(t *testing.T) {
-	tmp := setupTestDirs(t)
-
-	// Only new path exists (legacy removed = migration complete)
-	newDir := filepath.Join(tmp, ".config", "tabby")
-	os.MkdirAll(newDir, 0755)
-	os.WriteFile(filepath.Join(newDir, "config.yaml"), []byte("new"), 0644)
-
-	got := ConfigDir()
-	if got != newDir {
-		t.Errorf("ConfigDir() = %q, want new path %q", got, newDir)
-	}
-}
-
-func TestConfigDir_FallbackToLegacy(t *testing.T) {
-	tmp := setupTestDirs(t)
-
-	// Only create legacy path
-	legDir := filepath.Join(tmp, ".tmux", "plugins", "tmux-tabs")
-	os.MkdirAll(legDir, 0755)
-	os.WriteFile(filepath.Join(legDir, "config.yaml"), []byte("old"), 0644)
-
-	got := ConfigDir()
-	if got != legDir {
-		t.Errorf("ConfigDir() = %q, want legacy path %q", got, legDir)
-	}
-}
-
-func TestConfigDir_FreshInstall(t *testing.T) {
-	tmp := setupTestDirs(t)
-
-	// Neither path exists
 	want := filepath.Join(tmp, ".config", "tabby")
-	got := ConfigDir()
-	if got != want {
-		t.Errorf("ConfigDir() = %q, want canonical %q", got, want)
+	if got := ConfigDir(); got != want {
+		t.Errorf("ConfigDir() = %q, want %q", got, want)
 	}
 }
 
@@ -95,59 +43,23 @@ func TestStateDir_EnvOverride(t *testing.T) {
 	t.Setenv("TABBY_STATE_DIR", override)
 	ResetForTest()
 
-	got := StateDir()
-	if got != override {
+	if got := StateDir(); got != override {
 		t.Errorf("StateDir() = %q, want %q", got, override)
 	}
 }
 
-func TestStateDir_NewPathWins(t *testing.T) {
+func TestStateDir_Default(t *testing.T) {
 	tmp := setupTestDirs(t)
-
-	// Create new state dir (just needs to exist as a directory)
-	newDir := filepath.Join(tmp, ".local", "state", "tabby")
-	os.MkdirAll(newDir, 0755)
-
-	// Also create legacy state file
-	legDir := filepath.Join(tmp, ".config", "tabby")
-	os.MkdirAll(legDir, 0755)
-	os.WriteFile(filepath.Join(legDir, "pet.json"), []byte("{}"), 0644)
-
-	got := StateDir()
-	if got != newDir {
-		t.Errorf("StateDir() = %q, want new path %q", got, newDir)
-	}
-}
-
-func TestStateDir_FallbackToLegacy(t *testing.T) {
-	tmp := setupTestDirs(t)
-
-	// Only create legacy state file
-	legDir := filepath.Join(tmp, ".config", "tabby")
-	os.MkdirAll(legDir, 0755)
-	os.WriteFile(filepath.Join(legDir, "pet.json"), []byte("{}"), 0644)
-
-	got := StateDir()
-	if got != legDir {
-		t.Errorf("StateDir() = %q, want legacy path %q", got, legDir)
-	}
-}
-
-func TestStateDir_FreshInstall(t *testing.T) {
-	tmp := setupTestDirs(t)
-
 	want := filepath.Join(tmp, ".local", "state", "tabby")
-	got := StateDir()
-	if got != want {
-		t.Errorf("StateDir() = %q, want canonical %q", got, want)
+	if got := StateDir(); got != want {
+		t.Errorf("StateDir() = %q, want %q", got, want)
 	}
 }
 
 func TestConfigPath(t *testing.T) {
 	tmp := setupTestDirs(t)
 	want := filepath.Join(tmp, ".config", "tabby", "config.yaml")
-	got := ConfigPath()
-	if got != want {
+	if got := ConfigPath(); got != want {
 		t.Errorf("ConfigPath() = %q, want %q", got, want)
 	}
 }
@@ -155,8 +67,7 @@ func TestConfigPath(t *testing.T) {
 func TestStatePath(t *testing.T) {
 	tmp := setupTestDirs(t)
 	want := filepath.Join(tmp, ".local", "state", "tabby", "pet.json")
-	got := StatePath("pet.json")
-	if got != want {
+	if got := StatePath("pet.json"); got != want {
 		t.Errorf("StatePath(\"pet.json\") = %q, want %q", got, want)
 	}
 }
@@ -172,7 +83,8 @@ func TestEnsureConfigDir_Creates(t *testing.T) {
 	if dir != expected {
 		t.Errorf("EnsureConfigDir() = %q, want %q", dir, expected)
 	}
-	if !dirExists(expected) {
+	info, err := os.Stat(expected)
+	if err != nil || !info.IsDir() {
 		t.Errorf("EnsureConfigDir() did not create directory %q", expected)
 	}
 }
@@ -188,33 +100,8 @@ func TestEnsureStateDir_Creates(t *testing.T) {
 	if dir != expected {
 		t.Errorf("EnsureStateDir() = %q, want %q", dir, expected)
 	}
-	if !dirExists(expected) {
+	info, err := os.Stat(expected)
+	if err != nil || !info.IsDir() {
 		t.Errorf("EnsureStateDir() did not create directory %q", expected)
-	}
-}
-
-func TestStateDir_FallbackOnThoughtBuffer(t *testing.T) {
-	tmp := setupTestDirs(t)
-
-	legDir := filepath.Join(tmp, ".config", "tabby")
-	os.MkdirAll(legDir, 0755)
-	os.WriteFile(filepath.Join(legDir, "thought_buffer.txt"), []byte("hello"), 0644)
-
-	got := StateDir()
-	if got != legDir {
-		t.Errorf("StateDir() = %q, want legacy path %q (triggered by thought_buffer.txt)", got, legDir)
-	}
-}
-
-func TestStateDir_FallbackOnWebToken(t *testing.T) {
-	tmp := setupTestDirs(t)
-
-	legDir := filepath.Join(tmp, ".config", "tabby")
-	os.MkdirAll(legDir, 0755)
-	os.WriteFile(filepath.Join(legDir, "web-token"), []byte("tok"), 0644)
-
-	got := StateDir()
-	if got != legDir {
-		t.Errorf("StateDir() = %q, want legacy path %q (triggered by web-token)", got, legDir)
 	}
 }

--- a/scripts/_config_path.sh
+++ b/scripts/_config_path.sh
@@ -2,19 +2,10 @@
 # Shared config path resolution for Tabby shell scripts.
 # Source this file; it sets TABBY_CONFIG_FILE.
 #
-# Resolution order:
-#   1. TABBY_CONFIG_DIR env var
-#   2. ~/.config/tabby/config.yaml  (new canonical path)
-#   3. ~/.tmux/plugins/tmux-tabs/config.yaml  (legacy)
+# Resolution: TABBY_CONFIG_DIR env > ~/.config/tabby/
 
 if [ -n "$TABBY_CONFIG_DIR" ]; then
     TABBY_CONFIG_FILE="$TABBY_CONFIG_DIR/config.yaml"
-elif [ -f "$HOME/.config/tabby/config.yaml" ]; then
-    TABBY_CONFIG_FILE="$HOME/.config/tabby/config.yaml"
-elif [ -f "$HOME/.tmux/plugins/tmux-tabs/config.yaml" ]; then
-    echo "[tabby] deprecation: reading config from ~/.tmux/plugins/tmux-tabs/ -- move it to ~/.config/tabby/" >&2
-    TABBY_CONFIG_FILE="$HOME/.tmux/plugins/tmux-tabs/config.yaml"
 else
-    # Default to new canonical path (will be created on install)
     TABBY_CONFIG_FILE="$HOME/.config/tabby/config.yaml"
 fi


### PR DESCRIPTION
## Summary
- Strip legacy fallback logic from `pkg/paths` -- just use XDG paths directly
- Simplify `_config_path.sh` to env override or `~/.config/tabby/`
- Remove legacy mention from README
- Tests reduced from 14 to 8 (no fallback cases to test)

Follow-up to #36.