### PR TITLE
fix: move width sync off render path to prevent deadlock

### DIFF
--- a/cmd/tabby-daemon/coordinator.go
+++ b/cmd/tabby-daemon/coordinator.go
@@ -3333,6 +3333,117 @@ func (c *Coordinator) handleWidthSync(clientID string, currentWidth int) {
 	}
 }
 
+// RunWidthSync checks all connected sidebar clients and resizes any whose width
+// doesn't match the global target. Called from the main event loop (not the render path)
+// to avoid blocking BroadcastRender with tmux subprocess calls.
+func (c *Coordinator) RunWidthSync(activeWindowID string) {
+	if c.sidebarCollapsed {
+		return
+	}
+
+	// Snapshot client widths
+	c.clientWidthsMu.RLock()
+	clientSnapshot := make(map[string]int, len(c.clientWidths))
+	for id, w := range c.clientWidths {
+		clientSnapshot[id] = w
+	}
+	c.clientWidthsMu.RUnlock()
+
+	if len(clientSnapshot) == 0 {
+		return
+	}
+
+	// Read per-window SyncWidth settings under stateMu BEFORE acquiring widthSyncMu
+	// (lock ordering: stateMu -> widthSyncMu)
+	syncSettings := make(map[string]bool)
+	c.stateMu.RLock()
+	for i := range c.windows {
+		syncSettings[c.windows[i].ID] = c.windows[i].SyncWidth
+	}
+	c.stateMu.RUnlock()
+
+	trackLock("widthSyncMu", "RunWidthSync")
+	c.widthSyncMu.Lock()
+
+	// Detect active window change
+	justBecameActive := activeWindowID != "" && c.lastActiveWindowID != activeWindowID
+	if justBecameActive {
+		coordinatorDebugLog.Printf("Width sync: active window changed to %s", activeWindowID)
+		c.lastActiveWindowID = activeWindowID
+	}
+
+	// Debounce: ignore resize events within 500ms of our last sync
+	sinceLast := time.Since(c.lastWidthSync)
+	if sinceLast < 500*time.Millisecond {
+		untrackLock("widthSyncMu")
+		c.widthSyncMu.Unlock()
+		return
+	}
+
+	// Build list of panes to resize (compute under lock, execute after unlock)
+	type resizeOp struct {
+		clientID    string
+		targetWidth int
+	}
+	var ops []resizeOp
+
+	for clientID, currentWidth := range clientSnapshot {
+		// Skip header clients
+		if strings.HasPrefix(clientID, "header:") {
+			continue
+		}
+
+		// Check per-window sync opt-out
+		if !syncSettings[clientID] {
+			continue
+		}
+
+		if c.globalWidth == 0 {
+			c.globalWidth = currentWidth
+		}
+
+		// If sidebar got squeezed or stretched to extreme values, restore to global
+		if (currentWidth < 10 || currentWidth > 80) && c.globalWidth >= 10 && c.globalWidth <= 80 {
+			coordinatorDebugLog.Printf("Width sync: %s out of bounds (%d), restoring to global %d", clientID, currentWidth, c.globalWidth)
+			targetWidth := c.boundedSidebarWidthForWindow(clientID, c.globalWidth)
+			ops = append(ops, resizeOp{clientID: clientID, targetWidth: targetWidth})
+			continue
+		}
+
+		targetWidth := c.boundedSidebarWidthForWindow(clientID, c.globalWidth)
+		if currentWidth != targetWidth {
+			coordinatorDebugLog.Printf("Width sync: window=%s current=%d target=%d", clientID, currentWidth, targetWidth)
+			ops = append(ops, resizeOp{clientID: clientID, targetWidth: targetWidth})
+		}
+	}
+
+	if len(ops) > 0 {
+		c.lastWidthSync = time.Now()
+	}
+
+	untrackLock("widthSyncMu")
+	c.widthSyncMu.Unlock()
+
+	// Execute tmux resize operations AFTER releasing all locks
+	for _, op := range ops {
+		listCtx, listCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		out, err := exec.CommandContext(listCtx, "tmux", "list-panes", "-t", op.clientID, "-F", "#{pane_id} #{pane_current_command}").Output()
+		listCancel()
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+			parts := strings.Split(line, " ")
+			if len(parts) >= 2 && strings.HasPrefix(parts[1], "sidebar") {
+				resizeCtx, resizeCancel := context.WithTimeout(context.Background(), 2*time.Second)
+				exec.CommandContext(resizeCtx, "tmux", "resize-pane", "-t", parts[0], "-x", fmt.Sprintf("%d", op.targetWidth)).Run()
+				resizeCancel()
+				break
+			}
+		}
+	}
+}
+
 func (c *Coordinator) persistSidebarWidthProfile(windowID string, width int) {
 	if windowID == "" || width < 10 {
 		return
@@ -3512,7 +3623,9 @@ func (c *Coordinator) RenderForClient(clientID string, width, height int) *daemo
 		height = 24
 	}
 
-	c.handleWidthSync(clientID, width)
+
+	// NOTE: Width sync has been moved off the render path to prevent deadlocks.
+	// It now runs from the main event loop via RunWidthSync().
 
 	// If sidebar is collapsed, render minimal expand button only
 	if c.sidebarCollapsed {

--- a/cmd/tabby-daemon/main.go
+++ b/cmd/tabby-daemon/main.go
@@ -1629,6 +1629,8 @@ func main() {
 					syncClientSizesFromTmux(server)
 					server.BroadcastRender()
 					t1b := time.Now()
+					// Width sync runs off the render path to prevent deadlocks
+					coordinator.RunWidthSync(activeWindowID)
 
 					// Heavy ops (spawn/cleanup/layout) only if enough time has
 					// passed since the last full refresh. This breaks the feedback
@@ -1709,6 +1711,8 @@ func main() {
 					_ = spawnedFallback
 					// Persist current layouts to disk for restart recovery
 					saveLayoutsToDisk(windows)
+					// Width sync as fallback for missed events
+					coordinator.RunWidthSync(activeWindowID)
 				})
 			case <-watchdogTicker.C:
 				ok := runLoopTask("watchdog", 6*time.Second, func() {


### PR DESCRIPTION
## Summary

- Move `handleWidthSync` off the synchronous `BroadcastRender` path to prevent deadlocks that caused the daemon watchdog to kill the process after 12+ seconds of stall
- New `RunWidthSync()` method runs from the main event loop (`signal_refresh` + `window_check` ticker), iterates all clients in one pass, and executes tmux resize calls only after releasing all locks
- Eliminates per-client `tmux display-message` call by reusing the already-known `activeWindowID` from the main loop

## Root Cause

`handleWidthSync` was called per-client inside `RenderForClient`, making blocking tmux subprocess calls (`display-message`, `list-panes`, `resize-pane`) on the synchronous `BroadcastRender` path. With 24 clients rendered sequentially and concurrent `BroadcastRender` calls (main loop + async input handler), this caused lock convoy on `widthSyncMu` and prevented the main loop from calling `recordHeartbeat()`, triggering the watchdog.

## Lifecycle Safety

- New client connects → next `signal_refresh` or `window_check` triggers width sync
- Client disconnects → `RemoveClient` removes from `clientWidths`, next sync skips it
- Window focus change → `updateActiveWindow()` + `signal_refresh` → width sync runs with correct active window
- User grow/shrink buttons → use `syncAllSidebarWidths()` directly (unaffected)
- Terminal resize → tmux hooks → USR1 → `signal_refresh` → width sync runs

## Testing

- Build passes: `go build ./cmd/tabby-daemon`
- Tests pass: `go test ./cmd/tabby-daemon`
- Live tested: daemon running fresh with zero deadlock/watchdog warnings