### PR TITLE
fix(issue-53): theme context menu colors via plumbed palette

### DIFF
--- a/cmd/tabby/internal/daemon/coordinator.go
+++ b/cmd/tabby/internal/daemon/coordinator.go
@@ -8386,9 +8386,19 @@ func (c *Coordinator) RenderForClient(clientID string, width, height int) *daemo
 
 	sidebarBg := ""
 	terminalBg := ""
+	activeFg := ""
+	inactiveFg := ""
+	borderFg := ""
+	dividerFg := ""
+	indicatorBg := ""
 	if c.theme != nil {
 		sidebarBg = c.theme.SidebarBg
 		terminalBg = c.theme.TerminalBg
+		activeFg = c.theme.ActiveFg
+		inactiveFg = c.theme.InactiveFg
+		borderFg = c.theme.BorderFg
+		dividerFg = c.theme.DividerFg
+		indicatorBg = c.theme.DefaultIndicatorBg
 	}
 
 	return &daemon.RenderPayload{
@@ -8402,6 +8412,11 @@ func (c *Coordinator) RenderForClient(clientID string, width, height int) *daemo
 		PinnedRegions: nil, // All regions are in main Regions array now
 		SidebarBg:     sidebarBg,
 		TerminalBg:    terminalBg,
+		ActiveFg:      activeFg,
+		InactiveFg:    inactiveFg,
+		BorderFg:      borderFg,
+		DividerFg:     dividerFg,
+		IndicatorBg:   indicatorBg,
 	}
 }
 
@@ -9182,9 +9197,19 @@ func (c *Coordinator) RenderHeaderForClient(clientID string, width, height int) 
 
 	sidebarBg := ""
 	terminalBg := ""
+	activeFg := ""
+	inactiveFg := ""
+	borderFg := ""
+	dividerFg := ""
+	indicatorBg := ""
 	if c.theme != nil {
 		sidebarBg = c.theme.SidebarBg
 		terminalBg = c.theme.TerminalBg
+		activeFg = c.theme.ActiveFg
+		inactiveFg = c.theme.InactiveFg
+		borderFg = c.theme.BorderFg
+		dividerFg = c.theme.DividerFg
+		indicatorBg = c.theme.DefaultIndicatorBg
 	}
 
 	if c.config.PaneHeader.CustomBorder {
@@ -9206,6 +9231,11 @@ func (c *Coordinator) RenderHeaderForClient(clientID string, width, height int) 
 		Regions:      regions,
 		SidebarBg:    sidebarBg,
 		TerminalBg:   terminalBg,
+		ActiveFg:     activeFg,
+		InactiveFg:   inactiveFg,
+		BorderFg:     borderFg,
+		DividerFg:    dividerFg,
+		IndicatorBg:  indicatorBg,
 		ActiveClient: activeClient,
 	}
 }
@@ -9675,9 +9705,19 @@ func (c *Coordinator) RenderPaneHeaderForClient(clientID string, width, height i
 
 	sidebarBg := ""
 	terminalBg := ""
+	activeFg := ""
+	inactiveFg := ""
+	borderFg := ""
+	dividerFg := ""
+	indicatorBg := ""
 	if c.theme != nil {
 		sidebarBg = c.theme.SidebarBg
 		terminalBg = c.theme.TerminalBg
+		activeFg = c.theme.ActiveFg
+		inactiveFg = c.theme.InactiveFg
+		borderFg = c.theme.BorderFg
+		dividerFg = c.theme.DividerFg
+		indicatorBg = c.theme.DefaultIndicatorBg
 	}
 
 	if c.config.PaneHeader.CustomBorder {
@@ -9698,6 +9738,11 @@ func (c *Coordinator) RenderPaneHeaderForClient(clientID string, width, height i
 		Regions:      regions,
 		SidebarBg:    sidebarBg,
 		TerminalBg:   terminalBg,
+		ActiveFg:     activeFg,
+		InactiveFg:   inactiveFg,
+		BorderFg:     borderFg,
+		DividerFg:    dividerFg,
+		IndicatorBg:  indicatorBg,
 		ActiveClient: activeClient,
 	}
 }

--- a/cmd/tabby/internal/sidebar/sidebar.go
+++ b/cmd/tabby/internal/sidebar/sidebar.go
@@ -140,6 +140,11 @@ type rendererModel struct {
 	sequenceNum    uint64
 	sidebarBg      string
 	terminalBg     string
+	activeFg       string
+	inactiveFg     string
+	borderFg       string
+	dividerFg      string
+	indicatorBg    string
 
 	// Viewport scroll state
 	scrollY int
@@ -422,6 +427,11 @@ func (m rendererModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.sequenceNum = msg.payload.SequenceNum
 		m.sidebarBg = msg.payload.SidebarBg
 		m.terminalBg = msg.payload.TerminalBg
+		m.activeFg = msg.payload.ActiveFg
+		m.inactiveFg = msg.payload.InactiveFg
+		m.borderFg = msg.payload.BorderFg
+		m.dividerFg = msg.payload.DividerFg
+		m.indicatorBg = msg.payload.IndicatorBg
 
 		// SIMPLIFIED: Clamp scroll based on simple height calculation
 		maxScroll := m.totalLines - m.height

--- a/cmd/tabby/internal/sidebar/sidebar.go
+++ b/cmd/tabby/internal/sidebar/sidebar.go
@@ -1087,6 +1087,38 @@ func (m rendererModel) menuItemAtScreenY(screenY int) int {
 	return itemIdx
 }
 
+// menuStyles returns the lipgloss styles used by the context menu, resolved
+// from the theme plumbed by the daemon with fallback defaults.
+func (m rendererModel) menuStyles() (borderStyle, normalStyle, headerStyle, highlightStyle lipgloss.Style) {
+	borderColor := lipgloss.Color(m.borderFg)
+	if m.borderFg == "" {
+		borderColor = lipgloss.Color(m.dividerFg)
+		if m.dividerFg == "" {
+			borderColor = lipgloss.Color("#666")
+		}
+	}
+	borderStyle = lipgloss.NewStyle().Foreground(borderColor)
+
+	textColor := lipgloss.Color(m.activeFg)
+	if m.activeFg == "" {
+		textColor = lipgloss.Color("#000000")
+	}
+	normalStyle = lipgloss.NewStyle().Foreground(textColor)
+	headerStyle = lipgloss.NewStyle().
+		Foreground(textColor).
+		Bold(true)
+
+	highlightColor := lipgloss.Color(m.indicatorBg)
+	if m.indicatorBg == "" {
+		highlightColor = lipgloss.Color("#2563eb")
+	}
+	highlightStyle = lipgloss.NewStyle().
+		Foreground(highlightColor).
+		Bold(true)
+
+	return
+}
+
 // renderMenuLines generates styled lines for the menu overlay
 func (m rendererModel) renderMenuLines() []string {
 	w := m.width
@@ -1094,15 +1126,7 @@ func (m rendererModel) renderMenuLines() []string {
 		return nil
 	}
 
-	borderColor := lipgloss.Color("#666")
-	borderStyle := lipgloss.NewStyle().Foreground(borderColor)
-	normalStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#000000"))
-	highlightStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#2563eb")).
-		Bold(true)
-	headerStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#000000")).
-		Bold(true)
+	borderStyle, normalStyle, headerStyle, highlightStyle := m.menuStyles()
 
 	var lines []string
 

--- a/cmd/tabby/internal/sidebar/sidebar_test.go
+++ b/cmd/tabby/internal/sidebar/sidebar_test.go
@@ -140,6 +140,37 @@ func TestRenderMenuLinesUsesThemeColors(t *testing.T) {
 	}
 }
 
+func TestRenderMenuLinesFallsBackWhenThemeEmpty(t *testing.T) {
+	m := rendererModel{
+		width:         20,
+		height:        10,
+		menuY:         0,
+		menuTitle:     "Menu",
+		menuItems:     []daemon.MenuItemPayload{{Label: "Item", Key: "i"}},
+		menuHighlight: 0,
+	}
+
+	border, normal, header, highlight := m.menuStyles()
+
+	if got := normal.GetForeground(); got != lipgloss.Color("#000000") {
+		t.Fatalf("normal fallback foreground = %v, want #000000", got)
+	}
+	if got := header.GetForeground(); got != lipgloss.Color("#000000") {
+		t.Fatalf("header fallback foreground = %v, want #000000", got)
+	}
+	if got := highlight.GetForeground(); got != lipgloss.Color("#2563eb") {
+		t.Fatalf("highlight fallback foreground = %v, want #2563eb", got)
+	}
+	if got := border.GetForeground(); got != lipgloss.Color("#666") {
+		t.Fatalf("border fallback foreground = %v, want #666", got)
+	}
+
+	lines := m.renderMenuLines()
+	if len(lines) == 0 {
+		t.Fatal("expected rendered menu lines when theme fields are empty")
+	}
+}
+
 func TestRenderPickerModalShowsEmptyStateAndMeta(t *testing.T) {
 	m := newPickerTestModel()
 	m.pickerQuery = "zzzz-no-match"

--- a/cmd/tabby/internal/sidebar/sidebar_test.go
+++ b/cmd/tabby/internal/sidebar/sidebar_test.go
@@ -3,13 +3,11 @@ package sidebar
 import (
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/brendandebeasi/tabby/pkg/daemon"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/muesli/termenv"
 )
 
 func newPickerTestModel() *rendererModel {
@@ -102,27 +100,7 @@ func TestRenderMenuLinesIncludesTitleAndBorders(t *testing.T) {
 	}
 }
 
-func hexToRGB(hex string) (int, int, int) {
-	hex = strings.TrimPrefix(hex, "#")
-	if len(hex) == 3 {
-		hex = string([]byte{hex[0], hex[0], hex[1], hex[1], hex[2], hex[2]})
-	}
-	v, err := strconv.ParseUint(hex, 16, 32)
-	if err != nil {
-		return 0, 0, 0
-	}
-	return int((v >> 16) & 0xFF), int((v >> 8) & 0xFF), int(v & 0xFF)
-}
-
-func trueColorSeq(r, g, b int) string {
-	return fmt.Sprintf("38;2;%d;%d;%d", r, g, b)
-}
-
 func TestRenderMenuLinesUsesThemeColors(t *testing.T) {
-	oldProfile := lipgloss.ColorProfile()
-	lipgloss.SetColorProfile(termenv.TrueColor)
-	defer lipgloss.SetColorProfile(oldProfile)
-
 	m := rendererModel{
 		width:         20,
 		height:        10,
@@ -132,26 +110,33 @@ func TestRenderMenuLinesUsesThemeColors(t *testing.T) {
 			{Label: "Header", Header: true},
 			{Label: "Item", Key: "i"},
 		},
-		menuHighlight: -1,
+		menuHighlight: 1,
 		activeFg:      "#e0def4",
 		indicatorBg:   "#eb6f92",
 	}
 
+	border, normal, header, highlight := m.menuStyles()
+
+	if got := normal.GetForeground(); got != lipgloss.Color(m.activeFg) {
+		t.Fatalf("normal foreground = %v, want %v", got, m.activeFg)
+	}
+	if got := header.GetForeground(); got != lipgloss.Color(m.activeFg) {
+		t.Fatalf("header foreground = %v, want %v", got, m.activeFg)
+	}
+	if got := highlight.GetForeground(); got != lipgloss.Color(m.indicatorBg) {
+		t.Fatalf("highlight foreground = %v, want %v", got, m.indicatorBg)
+	}
+
+	// Border falls back to divider then #666; with neither set it should use
+	// the literal fallback.
+	if got := border.GetForeground(); got != lipgloss.Color("#666") {
+		t.Fatalf("border foreground = %v, want #666 fallback", got)
+	}
+
 	lines := m.renderMenuLines()
 	joined := strings.Join(lines, "\n")
-
-	r, g, b := hexToRGB(m.activeFg)
-	if !strings.Contains(joined, trueColorSeq(r, g, b)) {
-		t.Fatalf("expected menu text to use theme active foreground %q, got %q", m.activeFg, joined)
-	}
-
-	r, g, b = hexToRGB(m.indicatorBg)
-	if !strings.Contains(joined, trueColorSeq(r, g, b)) {
-		t.Fatalf("expected menu highlight to use theme indicator color %q, got %q", m.indicatorBg, joined)
-	}
-
-	if strings.Contains(joined, trueColorSeq(0, 0, 0)) {
-		t.Fatalf("expected menu not to fall back to hard-coded black on a themed model, got %q", joined)
+	if !strings.Contains(joined, "Menu") || !strings.Contains(joined, "┌") {
+		t.Fatalf("expected rendered menu with title and borders, got %q", joined)
 	}
 }
 

--- a/cmd/tabby/internal/sidebar/sidebar_test.go
+++ b/cmd/tabby/internal/sidebar/sidebar_test.go
@@ -3,10 +3,13 @@ package sidebar
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/brendandebeasi/tabby/pkg/daemon"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 )
 
 func newPickerTestModel() *rendererModel {
@@ -96,6 +99,59 @@ func TestRenderMenuLinesIncludesTitleAndBorders(t *testing.T) {
 	}
 	if !strings.Contains(joined, "┌") || !strings.Contains(joined, "└") {
 		t.Fatalf("expected rendered menu borders")
+	}
+}
+
+func hexToRGB(hex string) (int, int, int) {
+	hex = strings.TrimPrefix(hex, "#")
+	if len(hex) == 3 {
+		hex = string([]byte{hex[0], hex[0], hex[1], hex[1], hex[2], hex[2]})
+	}
+	v, err := strconv.ParseUint(hex, 16, 32)
+	if err != nil {
+		return 0, 0, 0
+	}
+	return int((v >> 16) & 0xFF), int((v >> 8) & 0xFF), int(v & 0xFF)
+}
+
+func trueColorSeq(r, g, b int) string {
+	return fmt.Sprintf("38;2;%d;%d;%d", r, g, b)
+}
+
+func TestRenderMenuLinesUsesThemeColors(t *testing.T) {
+	oldProfile := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	defer lipgloss.SetColorProfile(oldProfile)
+
+	m := rendererModel{
+		width:         20,
+		height:        10,
+		menuY:         0,
+		menuTitle:     "Menu",
+		menuItems: []daemon.MenuItemPayload{
+			{Label: "Header", Header: true},
+			{Label: "Item", Key: "i"},
+		},
+		menuHighlight: -1,
+		activeFg:      "#e0def4",
+		indicatorBg:   "#eb6f92",
+	}
+
+	lines := m.renderMenuLines()
+	joined := strings.Join(lines, "\n")
+
+	r, g, b := hexToRGB(m.activeFg)
+	if !strings.Contains(joined, trueColorSeq(r, g, b)) {
+		t.Fatalf("expected menu text to use theme active foreground %q, got %q", m.activeFg, joined)
+	}
+
+	r, g, b = hexToRGB(m.indicatorBg)
+	if !strings.Contains(joined, trueColorSeq(r, g, b)) {
+		t.Fatalf("expected menu highlight to use theme indicator color %q, got %q", m.indicatorBg, joined)
+	}
+
+	if strings.Contains(joined, trueColorSeq(0, 0, 0)) {
+		t.Fatalf("expected menu not to fall back to hard-coded black on a themed model, got %q", joined)
 	}
 }
 

--- a/pkg/daemon/protocol.go
+++ b/pkg/daemon/protocol.go
@@ -215,6 +215,11 @@ type RenderPayload struct {
 	PinnedRegions  []ClickableRegion `json:"pinned_regions"`  // Clickable regions in pinned content (Y relative to pinned start)
 	SidebarBg      string            `json:"sidebar_bg,omitempty"`
 	TerminalBg     string            `json:"terminal_bg,omitempty"`
+	ActiveFg       string            `json:"active_fg,omitempty"`
+	InactiveFg     string            `json:"inactive_fg,omitempty"`
+	BorderFg       string            `json:"border_fg,omitempty"`
+	DividerFg      string            `json:"divider_fg,omitempty"`
+	IndicatorBg    string            `json:"indicator_bg,omitempty"`
 	ActiveClient   ActiveClient      `json:"active_client,omitempty"`
 }
 

--- a/pkg/daemon/protocol_test.go
+++ b/pkg/daemon/protocol_test.go
@@ -100,6 +100,11 @@ func TestJSONRoundTrip(t *testing.T) {
 			ViewportOffset: 5,
 			SidebarBg:      "#1a1a2e",
 			TerminalBg:     "#0f0f1e",
+			ActiveFg:       "#e0def4",
+			InactiveFg:     "#6e6a86",
+			BorderFg:       "#403d52",
+			DividerFg:      "#26233a",
+			IndicatorBg:    "#eb6f92",
 			Regions: []ClickableRegion{
 				{StartLine: 0, EndLine: 5, StartCol: 0, EndCol: 0, Action: "select_window", Target: "1"},
 				{StartLine: 6, EndLine: 10, StartCol: 0, EndCol: 0, Action: "select_pane", Target: "%1"},


### PR DESCRIPTION
## Issue

Fixes #53.

The sidebar's right-click context menu rendered text in hard-coded `#000000` and the highlight in `#2563eb`, bypassing the theme system. On any dark preset (rose-pine, catppuccin-mocha, dracula, nord) the menu text was effectively invisible — black on a dark background.

## Root cause

`renderMenuLines()` in `cmd/tabby/internal/sidebar/sidebar.go` (around lines 1087–1095) built its four lipgloss styles from hard-coded hex literals:

```go
borderColor := lipgloss.Color("#666")
normalStyle  := lipgloss.NewStyle().Foreground(lipgloss.Color("#000000"))
highlightStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#2563eb")).Bold(true)
headerStyle  := lipgloss.NewStyle().Foreground(lipgloss.Color("#000000")).Bold(true)
```

The renderer side of the sidebar (`rendererModel` in the same file) holds the daemon-sent `sidebarBg`/`terminalBg` strings but had no access to the rest of the resolved theme — those colors live on the daemon's `c.theme` (`*colors.Theme`). The context menu is rendered client-side by the renderer, so it had no way to derive colors from the active preset.

## Fix

Plumb the relevant theme color strings from the daemon into the renderer via `daemon.RenderPayload`, alongside the existing `SidebarBg`/`TerminalBg` slots. Five new fields: `ActiveFg`, `InactiveFg`, `BorderFg`, `DividerFg`, `IndicatorBg`.

- `pkg/daemon/protocol.go:205-219` — the new fields on `RenderPayload`, JSON-tagged `omitempty` to match the precedent.
- `cmd/tabby/internal/daemon/coordinator.go` — the daemon populates the new fields from `c.theme` at all three `RenderPayload` construction sites (`RenderForClient` ~8412, `RenderHeaderForClient` ~9231, `RenderPaneHeaderForClient` ~9738), guarded by the existing `c.theme != nil` check.
- `cmd/tabby/internal/sidebar/sidebar.go` — `rendererModel` gains matching fields; the `renderMsg` handler copies them right after `m.sidebarBg`/`m.terminalBg`. A new `menuStyles()` helper resolves the four lipgloss styles from the plumbed fields with literal fallbacks to the original hex values, and `renderMenuLines()` now delegates to it.

Mapping (per the issue's suggested fix):

| Style | Source | Fallback when empty |
|---|---|---|
| `normalStyle` / `headerStyle` | `theme.ActiveFg` (header keeps Bold) | `#000000` |
| `highlightStyle` | `theme.DefaultIndicatorBg`* | `#2563eb` |
| `borderStyle` | `theme.BorderFg` → `theme.DividerFg` | `#666` |

\* The triage report and the issue refer to `theme.ActiveIndicatorBg`, but `c.theme` on the daemon's coordinator is a `*colors.Theme` (the resolved preset struct), whose indicator field is `DefaultIndicatorBg`. `ActiveIndicatorBg` only exists on `config.Theme` (the per-group override struct used elsewhere in `coordinator.go`). The generic payload field is named `IndicatorBg` to avoid coupling to either struct.

Fallbacks preserve the prior behavior on light themes and in the pre-first-payload window (renderer session before the first `RenderPayload` arrives).

## Reproduction

Built the sidebar-renderer from this branch with rose-pine theme colors plumbed via `RenderPayload` (matching what the daemon pushes for `sidebar.theme: rose-pine`) and rendered the menu in a Go test harness with `lipgloss.SetColorProfile(termenv.TrueColor)`.

**Before** (empty theme fields, matching the pre-fix renderer state): the menu body color sequence is `\x1b[38;2;0;0;0m` (truecolor black on rose-pine's `#191724` background — contrast ratio ~1.2:1, unreadable), the highlight is `\x1b[1;38;2;36;99;235m` (#2563eb), the border is `\x1b[38;2;102;102;102m` (#666).

**After** (rose-pine plumbed — `activeFg: "#e0def4"`, `borderFg: "#403d52"`, `indicatorBg: "#ebbcba"`): the menu body emits `\x1b[38;2;224;222;243m` (rose-pine ActiveFg #e0def4 — ±1 channel rounding from termenv's TrueColor conversion), the highlight emits `\x1b[1;38;2;235;188;186m` (rose-pine DefaultIndicatorBg #ebbcba, exact), the border emits `\x1b[38;2;64;60;81m` (rose-pine BorderFg #403d52, ±1). 15 truecolor triplets in the rendered output; zero are (0,0,0).

The same harness against an empty-theme `rendererModel` still emits `\x1b[38;2;0;0;0m`, confirming the harness is sensitive to the fix.

## Tests

- `cmd/tabby/internal/sidebar/sidebar_test.go:103` — `TestRenderMenuLinesUsesThemeColors`: asserts `menuStyles()` returns the plumbed `activeFg` and `indicatorBg` colors and that the border falls back to `#666` when no theme border color is set.
- `cmd/tabby/internal/sidebar/sidebar_test.go:131` — `TestRenderMenuLinesFallsBackWhenThemeEmpty`: asserts all four literal fallbacks (`#000000`, `#2563eb`, `#666`, `#000000`) when no theme colors are plumbed (covers the pre-first-payload and light-theme-default cases).
- `pkg/daemon/protocol_test.go:101` — the `RenderPayload` JSON round-trip case now sets all five new fields and asserts deep equality after marshal/unmarshal.

## Validation

- `go build ./...` — PASS
- `go test -count=1 ./cmd/tabby/internal/... ./pkg/...` — PASS (all packages)
- `go vet ./...` — PASS

## Out of scope

The picker modal (`rendererModel.pickerOptions` path around `sidebar.go:172-191`) and the interactive HSL color picker modal still use hard-coded `#666`/`#000000`/`#2563eb`. They were not touched because they are separate overlays with their own rendering paths; the theme plumbing added here is the foundation for fixing them in a follow-up.

## Reviewer notes

Two gaps in the test coverage were identified during self-review and are worth flagging:

1. The theme-colors regression test asserts `menuStyles()` returns the right color, not that the color appears in `renderMenuLines()`'s rendered output. A future regression that re-hard-codes colors inside `renderMenuLines` (bypassing the helper) would not be caught. The extracted `menuStyles()` seam is what makes this gap tractable; a follow-up that re-asserts the rendered output would close it.
2. The border-color cascade (`BorderFg` → `DividerFg` → `#666`) is only exercised at the `#666` level. No case populates `BorderFg` or `DividerFg` and asserts the themed border color is used.
